### PR TITLE
Fix typescript import extensions to include .ts / .tsx

### DIFF
--- a/packages/typescript/rules/fix.js
+++ b/packages/typescript/rules/fix.js
@@ -1,5 +1,14 @@
 module.exports = {
     rules: {
         'no-undef': 'off',
+        'import/extensions': [
+            'error', 'ignorePackages', {
+                'js': 'never',
+                'mjs': 'never',
+                'jsx': 'never',
+                'ts': 'never',
+                'tsx': 'never',
+            }
+        ],
     },
 };


### PR DESCRIPTION
>  **Pull request** :twisted_rightwards_arrows: created by @alex-oren on 2020-02-03 23:42:14
> Last updated on 2020-02-03 23:42:56
> Original Bitbucket pull request id: 12
>
> Source: https://github.com/willo32/willo-eslint/commit/7e1f5d6a1b3f on branch `fix/typescript-import-extensions`
> Destination: https://github.com/willo32/willo-eslint/commit/a8a79f76a635 on branch `devel`
> Merge commit: https://github.com/willo32/willo-eslint/commit/a8a79f76a635
>
> State: **`MERGED`**


