### PR TITLE
Allow for loops by default

### DIFF
--- a/packages/base/rules/style.js
+++ b/packages/base/rules/style.js
@@ -325,14 +325,6 @@ module.exports = {
         'no-restricted-syntax': [
             'error',
             {
-                selector: 'ForInStatement',
-                message: 'for..in loops iterate over the entire prototype chain, which is virtually never what you want. Use Object.{keys,values,entries}, and iterate over the resulting array.',
-            },
-            {
-                selector: 'ForOfStatement',
-                message: 'iterators/generators require regenerator-runtime, which is too heavyweight for this guide to allow them. Separately, loops should be avoided in favor of array iterations.',
-            },
-            {
                 selector: 'LabeledStatement',
                 message: 'Labels are a form of GOTO; using them makes code confusing and hard to maintain and understand.',
             },


### PR DESCRIPTION
>  **Pull request** :twisted_rightwards_arrows: created by @alex-oren on 2020-02-04 00:43:25
> Last updated on 2020-02-04 17:09:12
> Original Bitbucket pull request id: 14
>
> Source: https://github.com/willo32/willo-eslint/commit/92f9f049543c on branch `update/allow-for-loops`
> Destination: https://github.com/willo32/willo-eslint/commit/0ac44b1bb35a on branch `devel`
> Merge commit: https://github.com/willo32/willo-eslint/commit/0ac44b1bb35a
>
> State: **`MERGED`**

Because this rule makes no sense.   
We should be able to use for loops, it’s more performant than a .forEach or whatever shit exist to avoid for loops \+ it makes the code very ugly when dealing with an iterator which is not an array \(like a buffer\) because there’s no `.forEach` in such case

You should be able to do this:

`for (const byte of myBuffer) {`   
  
rather than:   
  
`myBuffer.values().forEach((byte) => {` 🤮

  
if you disagree, just look at which one is more readable
