### PR TITLE
import rule: Add a subgroup to gather our own import

### DIFF
--- a/packages/base/rules/imports.js
+++ b/packages/base/rules/imports.js
@@ -128,7 +128,7 @@ module.exports = {
         // https://github.com/benmosher/eslint-plugin-import/blob/master/docs/rules/order.md
         // TODO: enforce a stricter convention in module import order?
         'import/order': ['error', {
-            groups: [['builtin', 'external', 'internal']],
+            groups: ['builtin', 'external', ['internal', 'sibling', 'parent', 'index']],
             'newlines-between': 'always',
             alphabetize: { order: 'asc', caseInsensitive: true }
         }],


### PR DESCRIPTION
>  **Pull request** :twisted_rightwards_arrows: created by @mi-mazouz on 2020-03-04 23:32:15
> Last updated on 2020-03-04 23:32:26
> Original Bitbucket pull request id: 26
>
> Source: https://github.com/willo32/willo-eslint/commit/0fa7a1ec20a2 on branch `improve-import-order-group-rule`
> Destination: https://github.com/willo32/willo-eslint/commit/81c8cb5c934b on branch `devel`
> Merge commit: https://github.com/willo32/willo-eslint/commit/81c8cb5c934b
>
> State: **`MERGED`**


