### PR TITLE
fix/cd-workflow-typo

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -6,7 +6,7 @@ on:
       - v*.*.*
 
 jobs:
-  lint:
+  release:
 
     runs-on: ubuntu-latest
 


### PR DESCRIPTION
Fix release job naming